### PR TITLE
Use escape() instead of encodeURI()

### DIFF
--- a/angular-embedly.js
+++ b/angular-embedly.js
@@ -17,12 +17,12 @@ var angularEmbedly = angular.module('angular-embedly', []);
 
         function embedly($http) {
             this.embed = function(inputUrl) {
-                var escapedUrl = encodeURI(inputUrl);
+                var escapedUrl = escape(inputUrl);
                 var embedlyRequest = 'http://api.embed.ly/1/oembed?key=' + key + '&url=' +  escapedUrl;
                 return $http({method: 'GET', url: embedlyRequest});
             };
             this.extract = function(inputUrl) {
-                var escapedUrl = encodeURI(inputUrl);
+                var escapedUrl = escape(inputUrl);
                 var embedlyRequest = 'http://api.embed.ly/1/extract?key=' + key + '&url=' +  escapedUrl;
                 return $http({method: 'GET', url: embedlyRequest});
             };


### PR DESCRIPTION
Although escape is deprecated and should be replaced by encodeURI, Embed.ly still expects it to be used.

Using encodeURI on a google map url like:
https://www.google.com/maps/@39.8146794,-97.4038736,19z

results in a 404, whereas escape returns the expected output.
